### PR TITLE
Remove debug include dir

### DIFF
--- a/src/asyncmrsearch/internals/mrserver.c
+++ b/src/asyncmrsearch/internals/mrserver.c
@@ -1,7 +1,7 @@
 
 
 #include <Python.h>
-#include <python3.8d/structmember.h>
+#include <structmember.h>
 #include <stdbool.h>
 
 #include "mrserver.h"


### PR DESCRIPTION
I don't have the python 3.8 debug version installed so I had to remove that path in the structmember include statement.